### PR TITLE
 updated the bus to accept a prebuilt command

### DIFF
--- a/src/Bus.php
+++ b/src/Bus.php
@@ -122,6 +122,9 @@ class Bus implements CommandBusInterface
      */
     protected function mapInputToCommand($command, $input)
     {
+        if (is_object($command)) {
+            return $command;
+        }
         $dependencies = [];
         $class = new ReflectionClass($command);
         foreach ($class->getConstructor()->getParameters() as $parameter) {

--- a/tests/Bus/TestBus.php
+++ b/tests/Bus/TestBus.php
@@ -21,6 +21,15 @@ class TestBus extends TestCase{
         $this->assertInstanceOf('Joselfonseca\LaravelTactician\Tests\Stubs\TestCommand', $bus->dispatch('Joselfonseca\LaravelTactician\Tests\Stubs\TestCommand', [], []));
     }
 
+
+    public function test_it_accepts_prebuilt_command_objects()
+    {
+        $bus = app('Joselfonseca\LaravelTactician\CommandBusInterface');
+        $bus->addHandler('Joselfonseca\LaravelTactician\Tests\Stubs\TestCommand',
+            'Joselfonseca\LaravelTactician\Tests\Stubs\TestCommandHandler');
+        $this->assertInstanceOf('Joselfonseca\LaravelTactician\Tests\Stubs\TestCommand', $bus->dispatch(app('Joselfonseca\LaravelTactician\Tests\Stubs\TestCommand'), [], []));
+    }
+
     /**
      * Test if a a middleware can be applied to the stack
      */


### PR DESCRIPTION
Ran into a problem trying to use the command bus wherein I build the command using a static factory method (factory methods are currently unsupported by this package natively). This simple change will solve for this issue 