### PR TITLE
Spelling in Code Example & Punctuation Consistency

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@ Laravel Tactician in an implementation of the Command Bus Tactician by Ross Tuck
 
 ## Installation
 
-To install this update your composer.json file to require
+To install this update your composer.json file to require:
 
 ```json
     "joselfonseca/laravel-tactician" : "0.5.*"
@@ -18,11 +18,11 @@ To install this update your composer.json file to require
 
 #### >= laravel5.5
 
-ServiceProvider will be attached automatically
+ServiceProvider will be attached automatically.
 
 #### Other
 
-Once the dependencies have been downloaded, add the service provider to your config/app.php file
+Once the dependencies have been downloaded, add the service provider to your config/app.php file:
 
 ```php
     'providers' => [
@@ -35,12 +35,13 @@ You are done with the installation!
 
 ## Usage
 
-To use the command bus you can resolve the bus from the laravel container like so
+To use the command bus you can resolve the bus from the laravel container like so:
 
 ```php
     $bus = app('Joselfonseca\LaravelTactician\CommandBusInterface');
 ```
-Or you can inject it into a class constructor
+
+Or you can inject it into a class constructor:
 
 ```php
 
@@ -58,12 +59,13 @@ Or you can inject it into a class constructor
 
 ```
 
-Once you have the bus instance you can add your handler for the command to be dispatched
+Once you have the bus instance you can add your handler for the command to be dispatched:
 
 ```php
     $bus->addHandler('SomeCommand', 'SomeHandler');
 ```
-Now you can dispatch the command with the middleware.
+
+Now you can dispatch the command with the middleware:
 
 ```php
     // first parameter is the class name of the command
@@ -72,7 +74,7 @@ Now you can dispatch the command with the middleware.
     $bus->dispatch('SomeCommand', [], []);
 ```
 
-You can map the input data array of the Command's _constructor_ with plain list of arguments or the array itself. For example:
+You can map the input data array of the Command's _constructor_ with a plain list of arguments or the array itself. For example:
 
 ```php
     // Send parameters in an array of input data ...    
@@ -82,14 +84,14 @@ You can map the input data array of the Command's _constructor_ with plain list 
         'propertyThree' => 'Three',
     ], []);
     
-    // ... and recive them as individual parameters ... 
+    // ... and receive them as individual parameters ... 
     Class SomeCommand {
         public function __construct($propertyOne = 'A', $propertyTwo = 'B', $propertyThree = 'C'){
             //...
         }
     }
     
-    // ... or recive array of input data itself 
+    // ... or receive array of input data itself 
         Class SomeCommand {
             public function __construct(array $data = [
                 'propertyOne'   => 'A',
@@ -103,21 +105,21 @@ You can map the input data array of the Command's _constructor_ with plain list 
 
 Of course, you can use default values!
 
-For more information about the usage of the tactician command bus please visit [http://tactician.thephpleague.com/](http://tactician.thephpleague.com/)
+For more information about the usage of the tactician command bus please visit [http://tactician.thephpleague.com/](http://tactician.thephpleague.com/).
 
 ## Example
 
-Check out this example of the package implemented in a simple create order command [https://gist.github.com/joselfonseca/24ee0e96666a06b16f92](https://gist.github.com/joselfonseca/24ee0e96666a06b16f92)
+Check out this example of the package implemented in a simple create order command [https://gist.github.com/joselfonseca/24ee0e96666a06b16f92](https://gist.github.com/joselfonseca/24ee0e96666a06b16f92).
 
 ## Bindings
 
-You can configure the bindings for the locator, inflector, extractor and default bus publishing the config file like so
+You can configure the bindings for the locator, inflector, extractor and default bus by publishing the config file like so:
 
 ```bash
     php artisan vendor:publish
 ```
 
-Then you can modify each class name and they will be resolved from the laravel container
+Then you can modify each class name and they will be resolved from the laravel container:
 
 ```php
     return [
@@ -134,16 +136,16 @@ Then you can modify each class name and they will be resolved from the laravel c
 
 ## Generators
 
-You can generate Commands and Handlers automatically using artisan
+You can generate Commands and Handlers automatically using artisan:
 
 ```
 artisan make:tactician:command Foo
 artisan make:tactician:handler Foo
 ```
 
-This will create FooCommand and FooHandler and place them in the app/CommandBus/Commands and app/CommandBus/Handlers respectively
+This will create FooCommand and FooHandler and place them in the `app/CommandBus/Commands` and `app/CommandBus/Handlers` respectively.
 
-To run both at once
+To run both at once:
 
 ```
 artisan make:tactician Foo
@@ -151,7 +153,7 @@ artisan make:tactician Foo
 
 ## Middleware included
 
-Laravel tactician includes some useful middleware you can use in your commands
+Laravel tactician includes some useful middleware you can use in your commands.
 
 - Database Transactions: This Middleware will run the command inside a database transaction, if any exception is thrown the transaction won't be committed and the database will stay intact, you can find this middleware in `Joselfonseca\LaravelTactician\Middleware\DatabaseTransactions`.  
 
@@ -161,7 +163,7 @@ Please see the releases page [https://github.com/joselfonseca/laravel-tactician/
 
 ## Tests
 
-To run the test in this package, navigate to the root folder of the project and run
+To run the tests in this package, navigate to the root folder of the project and run:
 
 ```bash
     composer install


### PR DESCRIPTION
Fix `recive` [sic] vs `receive`.

Standardise punctuation.

resolves #13 