### PR TITLE
ReflectionParameter::isArray() is deprecated

### DIFF
--- a/src/Bus.php
+++ b/src/Bus.php
@@ -128,7 +128,7 @@ class Bus implements CommandBusInterface
         $dependencies = [];
         $class = new ReflectionClass($command);
         foreach ($class->getConstructor()->getParameters() as $parameter) {
-            if ( $parameter->getPosition() == 0 && $parameter->isArray() ) {
+            if ( $parameter->getPosition() == 0 && $parameter->getType() && $parameter->getType()->getName() === 'array') {
                 if ($input !== []) {
                     $dependencies[] = $input;
                 } else {


### PR DESCRIPTION
After update my project to use PHP 8 i face this error:

```
ErrorException: Method ReflectionParameter::isArray() is deprecated in file /var/www/vendor/joselfonseca/laravel-tactician/src/Bus.php on line 131
```